### PR TITLE
Update build requirements and options for Mixxx 2.1.0

### DIFF
--- a/mixxx.spec
+++ b/mixxx.spec
@@ -18,34 +18,36 @@ Patch0:         %{name}-%{version}-build.patch
 #Build tools
 BuildRequires:  desktop-file-utils
 BuildRequires:  libappstream-glib
+BuildRequires:  protobuf-compiler
 BuildRequires:  python2-scons
 
 #Mandatory Requirements
 BuildRequires:  alsa-lib-devel >= 1.0.10
 BuildRequires:  faad2-devel
+BuildRequires:  ffmpeg-devel
 BuildRequires:  fftw-devel
+BuildRequires:  flac-devel
 #BuildRequires:  jack-audio-connection-kit-devel >= 0.61.0 #jack seems deprecated to portaudio
-BuildRequires:  qt4-devel >= 4.3
 BuildRequires:  libGL-devel
 BuildRequires:  libGLU-devel
+BuildRequires:  libchromaprint-devel
 BuildRequires:  libid3tag-devel
 BuildRequires:  libmad-devel
+BuildRequires:  libmodplug-devel
 BuildRequires:  libmp4v2-devel
+BuildRequires:  libshout-devel
 BuildRequires:  libsndfile-devel
 BuildRequires:  libusb1-devel
 BuildRequires:  libvorbis-devel
-BuildRequires:  libmodplug-devel
+BuildRequires:  opus-devel
+BuildRequires:  opusfile-devel
 BuildRequires:  portaudio-devel
 BuildRequires:  portmidi-devel
-BuildRequires:  protobuf-devel protobuf-compiler
-BuildRequires:  taglib-devel
-BuildRequires:  flac-devel
-BuildRequires:  opus-devel opusfile-devel
-BuildRequires:  ffmpeg-devel
-BuildRequires:  libshout-devel
-BuildRequires:  sqlite-devel
+BuildRequires:  protobuf-devel
+BuildRequires:  qt4-devel >= 4.3
 BuildRequires:  rubberband-devel
-BuildRequires:  libchromaprint-devel
+BuildRequires:  sqlite-devel
+BuildRequires:  taglib-devel
 BuildRequires:  upower-devel
 BuildRequires:  wavpack-devel
 

--- a/mixxx.spec
+++ b/mixxx.spec
@@ -81,7 +81,7 @@ scons %{?_smp_mflags} \
   qtdir=%{_qt4_prefix} \
   faad=1 \
   shoutcast=1 \
-  optimize=0 \
+  optimize=portable \
 
 
 

--- a/mixxx.spec
+++ b/mixxx.spec
@@ -40,6 +40,7 @@ BuildRequires:  portmidi-devel
 BuildRequires:  protobuf-devel protobuf-compiler
 BuildRequires:  taglib-devel
 BuildRequires:  flac-devel
+BuildRequires:  opus-devel opusfile-devel
 BuildRequires:  libshout-devel
 BuildRequires:  sqlite-devel
 BuildRequires:  rubberband-devel
@@ -84,6 +85,7 @@ scons %{?_smp_mflags} \
   prefix=%{_prefix} \
   qtdir=%{_qt4_prefix} \
   faad=1 \
+  opus=1 \
   shoutcast=1 \
   wv=1 \
   modplug=1 \

--- a/mixxx.spec
+++ b/mixxx.spec
@@ -75,10 +75,10 @@ controllers including MIDI devices, and more.
 %prep
 %autosetup -p1 -n %{name}-%{commit}
 
-# TODO remove bundle libs
-#rm -rf lib/vamp lib/libebur128 lib/soundtouch-2.0.0 lib/xwax lib/gmock-1.7.0 lib/gtest-1.7.0
+# TODO remove bundle libs?
+#rm -rf lib/libebur128* lib/soundtouch* lib/vamp lib/xwax lib/gmock* lib/gtest*
 
- 
+
 
 %build
 export CFLAGS=$RPM_OPT_FLAGS

--- a/mixxx.spec
+++ b/mixxx.spec
@@ -41,6 +41,7 @@ BuildRequires:  protobuf-devel protobuf-compiler
 BuildRequires:  taglib-devel
 BuildRequires:  flac-devel
 BuildRequires:  opus-devel opusfile-devel
+BuildRequires:  ffmpeg-devel
 BuildRequires:  libshout-devel
 BuildRequires:  sqlite-devel
 BuildRequires:  rubberband-devel
@@ -86,6 +87,7 @@ scons %{?_smp_mflags} \
   qtdir=%{_qt4_prefix} \
   faad=1 \
   opus=1 \
+  ffmpeg=1 \
   shoutcast=1 \
   wv=1 \
   modplug=1 \

--- a/mixxx.spec
+++ b/mixxx.spec
@@ -3,7 +3,6 @@
 %global shortcommit0 %(c=%{commit}; echo ${c:0:7})
 
 %bcond_with bpm
-%bcond_with djconsole
 %bcond_with libgpod
 
 Name:           mixxx
@@ -27,7 +26,6 @@ BuildRequires:  alsa-lib-devel >= 1.0.10
 BuildRequires:  faad2-devel
 #BuildRequires:  jack-audio-connection-kit-devel >= 0.61.0 #jack seems deprecated to portaudio
 BuildRequires:  qt4-devel >= 4.3
-BuildRequires:  qt4-webkit-devel
 BuildRequires:  libGL-devel
 BuildRequires:  libGLU-devel
 BuildRequires:  libid3tag-devel
@@ -52,8 +50,6 @@ BuildRequires:  vamp-plugin-sdk-devel
 #BuildRequires:  python-devel
 #BuildRequires:  lua-devel, tolua++-devel
 %{?with_bpm:BuildRequires: fftw-devel}
-%{?with_djconsole:BuildRequires: idjc}
-BuildRequires: ladspa-devel
 %{?with_libgpod:BuildRequires: libgpod-devel}
 BuildRequires: wavpack-devel
 
@@ -84,8 +80,8 @@ scons %{?_smp_mflags} \
   prefix=%{_prefix} \
   qtdir=%{_qt4_prefix} \
   faad=1 \
-  ladspa=0 \
-  shoutcast=1 hifieq=1 script=0 optimize=0 \
+  shoutcast=1 \
+  optimize=0 \
 
 
 

--- a/mixxx.spec
+++ b/mixxx.spec
@@ -34,6 +34,7 @@ BuildRequires:  libmp4v2-devel
 BuildRequires:  libsndfile-devel
 BuildRequires:  libusb1-devel
 BuildRequires:  libvorbis-devel
+BuildRequires:  libmodplug-devel
 BuildRequires:  portaudio-devel
 BuildRequires:  portmidi-devel
 BuildRequires:  protobuf-devel protobuf-compiler
@@ -85,6 +86,7 @@ scons %{?_smp_mflags} \
   faad=1 \
   shoutcast=1 \
   wv=1 \
+  modplug=1 \
   optimize=portable \
 
 

--- a/mixxx.spec
+++ b/mixxx.spec
@@ -87,13 +87,13 @@ export LIBDIR=%{_libdir}
 scons %{?_smp_mflags} \
   prefix=%{_prefix} \
   qtdir=%{_qt4_prefix} \
+  optimize=portable \
   faad=1 \
-  opus=1 \
   ffmpeg=1 \
+  modplug=1 \
+  opus=1 \
   shoutcast=1 \
   wv=1 \
-  modplug=1 \
-  optimize=portable \
 
 
 

--- a/mixxx.spec
+++ b/mixxx.spec
@@ -44,6 +44,7 @@ BuildRequires:  sqlite-devel
 BuildRequires:  rubberband-devel
 BuildRequires:  libchromaprint-devel
 BuildRequires:  upower-devel
+BuildRequires:  wavpack-devel
 
 #Bundled Requirements
 #BuildRequires:  libebur128-devel
@@ -54,7 +55,6 @@ BuildRequires:  upower-devel
 #BuildRequires:  python-devel
 #BuildRequires:  lua-devel, tolua++-devel
 %{?with_libgpod:BuildRequires: libgpod-devel}
-BuildRequires: wavpack-devel
 
 # workaround to use phonon-backend-gstreamer instead of phonon-backend-vlc since phonon-backend-vlc
 # is broken in rpmfusion currently
@@ -84,6 +84,7 @@ scons %{?_smp_mflags} \
   qtdir=%{_qt4_prefix} \
   faad=1 \
   shoutcast=1 \
+  wv=1 \
   optimize=portable \
 
 

--- a/mixxx.spec
+++ b/mixxx.spec
@@ -39,14 +39,18 @@ BuildRequires:  portmidi-devel
 BuildRequires:  protobuf-devel protobuf-compiler
 BuildRequires:  taglib-devel
 BuildRequires:  flac-devel
+BuildRequires:  libshout-devel
 BuildRequires:  sqlite-devel
 BuildRequires:  rubberband-devel
 BuildRequires:  libchromaprint-devel
 BuildRequires:  upower-devel
 
-#Optionals Requirements
-BuildRequires:  libshout-devel
-BuildRequires:  vamp-plugin-sdk-devel
+#Bundled Requirements
+#BuildRequires:  libebur128-devel
+#BuildRequires:  soundtouch-devel
+#BuildRequires:  vamp-plugin-sdk-devel
+
+#Optional Requirements
 #BuildRequires:  python-devel
 #BuildRequires:  lua-devel, tolua++-devel
 %{?with_libgpod:BuildRequires: libgpod-devel}
@@ -67,7 +71,7 @@ controllers including MIDI devices, and more.
 %autosetup -p1 -n %{name}-%{commit}
 
 # TODO remove bundle libs
-#rm -rf lib/vamp-2.3 lib/xwax lib/gmock-1.7.0 lib/gtest-1.7.0
+#rm -rf lib/vamp lib/libebur128 lib/soundtouch-2.0.0 lib/xwax lib/gmock-1.7.0 lib/gtest-1.7.0
 
  
 

--- a/mixxx.spec
+++ b/mixxx.spec
@@ -2,7 +2,6 @@
 %global date 20180204
 %global shortcommit0 %(c=%{commit}; echo ${c:0:7})
 
-%bcond_with bpm
 %bcond_with libgpod
 
 Name:           mixxx
@@ -24,6 +23,7 @@ BuildRequires:  python2-scons
 #Mandatory Requirements
 BuildRequires:  alsa-lib-devel >= 1.0.10
 BuildRequires:  faad2-devel
+BuildRequires:  fftw-devel
 #BuildRequires:  jack-audio-connection-kit-devel >= 0.61.0 #jack seems deprecated to portaudio
 BuildRequires:  qt4-devel >= 4.3
 BuildRequires:  libGL-devel
@@ -49,7 +49,6 @@ BuildRequires:  libshout-devel
 BuildRequires:  vamp-plugin-sdk-devel
 #BuildRequires:  python-devel
 #BuildRequires:  lua-devel, tolua++-devel
-%{?with_bpm:BuildRequires: fftw-devel}
 %{?with_libgpod:BuildRequires: libgpod-devel}
 BuildRequires: wavpack-devel
 


### PR DESCRIPTION
As promised I've collected a set of changes to support the distribution of the upcoming version 2.1.0. All modifications separated into individual commits for easy review and assessment.

I was able to build and install RPMs for fc27.x86_64 locally without any issues using the default python2-scons 3.0.1.

@Be-ing As a Fedora user you might have a look at this, too?